### PR TITLE
Move to Alpine 3.2 stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.2
 MAINTAINER Vladimir Krivosheev <develar@gmail.com>
 
 ENV JAVA_VERSION_MAJOR 8


### PR DESCRIPTION
Alpine 3.2 got released a month ago, so it can be considered tested by time.
