### PR TITLE
Downgrade to alpine 3.2 until openssl is fixed in 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.2
 MAINTAINER Vladimir Krivosheev <develar@gmail.com>
 
 ENV JAVA_VERSION_MAJOR=8  \


### PR DESCRIPTION
As described in #9, openssl is broken in 3.3 currently. I would recommend downgrading to 3.2 for now, but it is entirely up to you. We build a container `FROM develar/java8u45` right now, but I can understand if you do not want to support our use case.
