### PR TITLE
Updated Java version to 8u92-b14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.3
 MAINTAINER Vladimir Krivosheev <develar@gmail.com>
 
 ENV JAVA_VERSION_MAJOR=8  \
-    JAVA_VERSION_MINOR=77 \
-    JAVA_VERSION_BUILD=03 \
+    JAVA_VERSION_MINOR=92 \
+    JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=server-jre \
     JAVA_HOME=/jre \
     PATH=${PATH}:/jre/bin \


### PR DESCRIPTION
```
docker run --rm -it develar/java -version
java version "1.8.0_92"
Java(TM) SE Runtime Environment (build 1.8.0_92-b14)
Java HotSpot(TM) 64-Bit Server VM (build 25.92-b14, mixed mode)
```
